### PR TITLE
Bump dependencies and remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ keywords = ["clipboard"]
 edition = "2018"
 readme = "README.md"
 
-[dependencies]
-anyhow = "1.0.31"
-
 [target.'cfg(windows)'.dependencies]
 clipboard-win = {version = "4.0.2", features=["std"]}
 
@@ -21,6 +18,5 @@ objc_id = "0.1"
 objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
-failure = "0.1"
 wl-clipboard-rs = "0.6"
 x11-clipboard = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 wl-clipboard-rs = "0.6"
-x11-clipboard = "0.5.1"
+x11-clipboard = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ objc-foundation = "0.1"
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 failure = "0.1"
-wl-clipboard-rs = "0.4"
+wl-clipboard-rs = "0.6"
 x11-clipboard = "0.5.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use anyhow::Result;
+use crate::Result;
 
 /// Trait for clipboard access
 pub trait ClipboardProvider: Sized {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ extern crate x11_clipboard as x11_clipboard_crate;
 #[macro_use]
 extern crate objc;
 
-use anyhow::Result;
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 mod common;
 pub use common::ClipboardProvider;

--- a/src/linux_clipboard.rs
+++ b/src/linux_clipboard.rs
@@ -1,7 +1,7 @@
 use crate::common::*;
 use crate::wayland_clipboard::WaylandClipboardContext;
 use crate::x11_clipboard::{Clipboard, X11ClipboardContext};
-use anyhow::Result;
+use crate::Result;
 
 enum LinuxContext {
     Wayland(WaylandClipboardContext),

--- a/src/macos_clipboard.rs
+++ b/src/macos_clipboard.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use crate::common::*;
-use anyhow::{anyhow, Result};
+use crate::Result;
 use objc::runtime::{Class, Object};
 use objc_foundation::{INSArray, INSObject, INSString};
 use objc_foundation::{NSArray, NSDictionary, NSObject, NSString};
@@ -32,11 +32,10 @@ extern "C" {}
 
 impl ClipboardProvider for MacOSClipboardContext {
     fn new() -> Result<MacOSClipboardContext> {
-        let cls =
-            Class::get("NSPasteboard").ok_or_else(|| anyhow!("Class::get(\"NSPasteboard\")"))?;
+        let cls = Class::get("NSPasteboard").ok_or_else(|| "Class::get(\"NSPasteboard\")")?;
         let pasteboard: *mut Object = unsafe { msg_send![cls, generalPasteboard] };
         if pasteboard.is_null() {
-            return Err(anyhow!("NSPasteboard#generalPasteboard returned null"));
+            return Err("NSPasteboard#generalPasteboard returned null".into());
         }
         let pasteboard: Id<Object> = unsafe { Id::from_ptr(pasteboard) };
         Ok(MacOSClipboardContext { pasteboard })
@@ -53,16 +52,12 @@ impl ClipboardProvider for MacOSClipboardContext {
             let obj: *mut NSArray<NSString> =
                 msg_send![self.pasteboard, readObjectsForClasses:&*classes options:&*options];
             if obj.is_null() {
-                return Err(anyhow!(
-                    "pasteboard#readObjectsForClasses:options: returned null",
-                ));
+                return Err("pasteboard#readObjectsForClasses:options: returned null".into());
             }
             Id::from_ptr(obj)
         };
         if string_array.count() == 0 {
-            Err(anyhow!(
-                "pasteboard#readObjectsForClasses:options: returned empty",
-            ))
+            Err("pasteboard#readObjectsForClasses:options: returned empty".into())
         } else {
             Ok(string_array[0].as_str().to_owned())
         }
@@ -75,7 +70,7 @@ impl ClipboardProvider for MacOSClipboardContext {
         if success {
             Ok(())
         } else {
-            Err(anyhow!("NSPasteboard#writeObjects: returned false"))
+            Err("NSPasteboard#writeObjects: returned false".into())
         }
     }
 

--- a/src/windows_clipboard.rs
+++ b/src/windows_clipboard.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use clipboard_win::{empty, get_clipboard_string, set_clipboard_string, Clipboard};
 
 use crate::common::ClipboardProvider;
-use anyhow::Result;
+use crate::Result;
 
 pub struct WindowsClipboardContext;
 

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -18,7 +18,7 @@ use crate::common::*;
 use crate::Result;
 use std::marker::PhantomData;
 use std::time::Duration;
-use x11_clipboard_crate::xcb::xproto::Atom;
+use x11_clipboard_crate::xcb::x::Atom;
 use x11_clipboard_crate::Atoms;
 use x11_clipboard_crate::Clipboard as X11Clipboard;
 

--- a/src/x11_clipboard.rs
+++ b/src/x11_clipboard.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use crate::common::*;
-use anyhow::Result;
+use crate::Result;
 use std::marker::PhantomData;
 use std::time::Duration;
 use x11_clipboard_crate::xcb::xproto::Atom;


### PR DESCRIPTION
Closes #9

<del>For the removal of the `failure` dependency, this requires a new release of `wl-clipboard-rs`.</del> There has been a new release, so we're good now.